### PR TITLE
Add a rule to check if IP Address is IPv4 Cidr

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -137,8 +137,12 @@ func getExtension(domain string) string {
 	ext := domain
 
 	if net.ParseIP(domain) == nil {
-		domains := strings.Split(domain, ".")
-		ext = domains[len(domains)-1]
+		if net.ParseIP(strings.Split(domain, "/")[0]) != nil {
+			ext = strings.Split(domain, "/")[0]
+		} else {
+			domains := strings.Split(domain, ".")
+			ext = domains[len(domains)-1]
+		}
 	}
 
 	if strings.Contains(ext, "/") {


### PR DESCRIPTION
Because the existing rules will cause IPv4 Cidr to be ignored, So add a rule to check

![](https://user-images.githubusercontent.com/43361940/113050766-cb50d300-91d7-11eb-9feb-efefbc86fe01.png)
