### PR TITLE
Error Updates

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,11 @@
+package whois
+
+import "errors"
+
+var (
+	// ErrDomainEmpty domain is an empty string
+	ErrDomainEmpty = errors.New("domain is empty")
+
+	// ErrWhoisServerNotFound no whois server found
+	ErrWhoisServerNotFound = errors.New("no whois server found for domain")
+)

--- a/whois.go
+++ b/whois.go
@@ -104,7 +104,7 @@ func (c *Client) Whois(domain string, servers ...string) (result string, err err
 
 	domain = strings.Trim(strings.TrimSpace(domain), ".")
 	if domain == "" {
-		return "", fmt.Errorf("whois: domain is empty")
+		return "", fmt.Errorf("whois: %w", ErrDomainEmpty)
 	}
 
 	isASN := IsASN(domain)
@@ -127,7 +127,7 @@ func (c *Client) Whois(domain string, servers ...string) (result string, err err
 		}
 		server = getServer(result)
 		if server == "" {
-			return "", fmt.Errorf("whois: no whois server found for domain: %s", domain)
+			return "", fmt.Errorf("whois: %w: %s", ErrWhoisServerNotFound, domain)
 		}
 	} else {
 		server = strings.ToLower(servers[0])

--- a/whois.go
+++ b/whois.go
@@ -123,7 +123,7 @@ func (c *Client) Whois(domain string, servers ...string) (result string, err err
 		ext := getExtension(domain)
 		result, err := c.rawQuery(ext, defaultWhoisServer)
 		if err != nil {
-			return "", fmt.Errorf("whois: query for whois server failed: %v", err)
+			return "", fmt.Errorf("whois: query for whois server failed: %w", err)
 		}
 		server = getServer(result)
 		if server == "" {
@@ -170,7 +170,7 @@ func (c *Client) rawQuery(domain, server string) (string, error) {
 
 	conn, err := c.dialer.Dial("tcp", net.JoinHostPort(server, defaultWhoisPort))
 	if err != nil {
-		return "", fmt.Errorf("whois: connect to whois server failed: %v", err)
+		return "", fmt.Errorf("whois: connect to whois server failed: %w", err)
 	}
 
 	defer conn.Close()
@@ -179,7 +179,7 @@ func (c *Client) rawQuery(domain, server string) (string, error) {
 	_ = conn.SetWriteDeadline(time.Now().Add(c.timeout - c.elapsed))
 	_, err = conn.Write([]byte(domain + "\r\n"))
 	if err != nil {
-		return "", fmt.Errorf("whois: send to whois server failed: %v", err)
+		return "", fmt.Errorf("whois: send to whois server failed: %w", err)
 	}
 
 	c.elapsed = time.Since(start)
@@ -187,7 +187,7 @@ func (c *Client) rawQuery(domain, server string) (string, error) {
 	_ = conn.SetReadDeadline(time.Now().Add(c.timeout - c.elapsed))
 	buffer, err := ioutil.ReadAll(conn)
 	if err != nil {
-		return "", fmt.Errorf("whois: read from whois server failed: %v", err)
+		return "", fmt.Errorf("whois: read from whois server failed: %w", err)
 	}
 
 	c.elapsed = time.Since(start)


### PR DESCRIPTION
Hello!

I really appreciate your work on this repo.  
This pull request makes two changes to the way errors are handled in this repo.

1. Detecting which error has occurred with `errors.Is()` is not possible unless errors are formatted with `%w` instead of `%v`. See [here](https://go.dev/blog/go1.13-errors) for more detail.
2. Splitting out some of the local errors into public variables (`ErrDomainEmpty` and `ErrWhoisServerNotFound`) will let callers check to see if one of these errors occurred. For example `errors.Is(err, whois.ErrWhoisServerNotFound)`