### PR TITLE
Improve getServer() parser

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -227,6 +227,7 @@ func getServer(data string) (string, string) {
 			start += len(token)
 			end := strings.Index(data[start:], "\n")
 			server := strings.TrimSpace(data[start : start+end])
+			server = strings.TrimPrefix(server, "http:")
 			server = strings.TrimPrefix(server, "whois:")
 			server = strings.TrimPrefix(server, "rwhois:")
 			server = strings.Trim(server, "/")


### PR DESCRIPTION
Fixes this error:

connect to whois server failed: dial tcp: lookup
tcp///whois.namecheap.com: Servname not supported for ai_socktype

Observed on an org TLD domain, whose whois response contains:

Registrar WHOIS Server: http://whois.namecheap.com