### PR TITLE
whois: getServer: add refer: as valid refering server prefix

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -221,6 +221,7 @@ func getExtension(domain string) string {
 func getServer(data string) (string, string) {
 	tokens := []string{
 		"Registrar WHOIS Server: ",
+		"refer: ",
 		"whois: ",
 		"ReferralServer: ",
 	}


### PR DESCRIPTION
As specified at http://www.iana.org/help/whois, IANA will send a `refer:` entry where data can be retrieved. It should also be prioritized over the `whois:` entry.