### PR TITLE
Fix SetTimeout not changing the timeout in the underlying Dialer

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -53,6 +53,15 @@ type Client struct {
 	disableReferral bool
 }
 
+type hasDial interface {
+	Dial(network, addr string) (net.Conn, error)
+}
+
+type hasTimeout struct {
+	Timeout time.Duration
+	hasDial
+}
+
 // Version returns package version
 func Version() string {
 	return "1.15.4"
@@ -92,6 +101,10 @@ func (c *Client) SetDialer(dialer proxy.Dialer) *Client {
 // SetTimeout set query timeout
 func (c *Client) SetTimeout(timeout time.Duration) *Client {
 	c.timeout = timeout
+	if d, ok := c.dialer.(*hasTimeout); ok {
+		fmt.Println("hasTimeout")
+		d.Timeout = timeout
+	}
 	return c
 }
 

--- a/whois.go
+++ b/whois.go
@@ -96,11 +96,10 @@ func (c *Client) SetDialer(dialer proxy.Dialer) *Client {
 
 // SetTimeout set query timeout
 func (c *Client) SetTimeout(timeout time.Duration) *Client {
-	c.timeout = timeout
 	if d, ok := c.dialer.(*hasTimeout); ok {
-		fmt.Println("hasTimeout")
 		d.Timeout = timeout
 	}
+	c.timeout = timeout
 	return c
 }
 

--- a/whois.go
+++ b/whois.go
@@ -53,13 +53,9 @@ type Client struct {
 	disableReferral bool
 }
 
-type hasDial interface {
-	Dial(network, addr string) (net.Conn, error)
-}
-
 type hasTimeout struct {
 	Timeout time.Duration
-	hasDial
+	proxy.Dialer
 }
 
 // Version returns package version

--- a/whois_test.go
+++ b/whois_test.go
@@ -71,6 +71,18 @@ func TestWhoisFail(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestWhoisTimeout(t *testing.T) {
+	client := NewClient()
+	client.SetTimeout(1 * time.Millisecond)
+	_, err := client.Whois("google.com")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+
+	client.SetTimeout(10 * time.Second)
+	_, err = client.Whois("google.com")
+	assert.Nil(t, err)
+}
+
 func TestWhois(t *testing.T) {
 	tests := []string{
 		"com",


### PR DESCRIPTION
This branch solves the dialer timeout issue mentioned in #43 and #37.

It does so by creating a dummy struct `hasTimeout` which has the `Timeout` field in its struct, and composes proxy.Dialer. This effectively creates a new struct with one property, Timeout, and one method, Dial.

It then uses this dummy type to assert that the client.Dialer has the Timeout property. If it does, it is now able to set the Timeout property in the actual Dialer. This is all necessary because client uses `proxy.Dialer` which is a more general interface than `net.Dialer` and lacks the Timeout method, so Golang does not believe it has the property unless it is specifically asserted that it does.

We could achieve this without creating a new type simply by asserting that client.Dialer is `net.Dialer` (i.e. `if d, ok := c.dialer.(*net.Dialer)`, but then all Dialers would need to fully implement net.Dialer struct which might be incompatible with some uses of the application.

Indeed, this implementation might not work already for any custom dialers that do not have the `Timeout` property (see Drawbacks).

# Drawbacks

This implementation has a couple of drawbacks. It should probably modify the SetDialer method to also return an error if client.Dialer does not have the Timeout, otherwise it will silently fail to change the timeout if someone is using a custom Dialer that does not implement a Timeout. However, I did not want to change the signature of a method as that is a breaking change, so I leave it to @likexian to determine if that is reasonable.

If this is desired, the implementation would look like

```go
// SetTimeout set query timeout
func (c *Client) SetTimeout(timeout time.Duration) (*Client, error ) {
	if d, ok := c.dialer.(*hasTimeout); ok {
		d.Timeout = timeout
		c.timeout = timeout
		return c, nil
	}
	return nil, fmt.Errorf("whois: dialer does not support timeout")
}
```

Generally, this is also just a bit of an awkward way to go about fixing this. There are probably cleaner ways to fix the problem (as mentioned in one of the Issues, a context could help), but this is certainly one of the fastest ways to resolve.

I welcome feedback on this change!