### PR TITLE
Update getServer to handle %referral and rwhois urls.

### DIFF
--- a/testdata/rwhois_shawcable_net_4321_174.txt
+++ b/testdata/rwhois_shawcable_net_4321_174.txt
@@ -1,0 +1,3 @@
+%rwhois V-1.5:003fff:00 rs1so.cg.shawcable.net (by Network Solutions, Inc. V-1.5.9.5)
+%referral rwhois://root.rwhois.net:4321/auth-area=.
+%ok

--- a/testdata/whois_apnic_net_171.txt
+++ b/testdata/whois_apnic_net_171.txt
@@ -1,0 +1,128 @@
+
+% [whois.apnic.net]
+% Whois data copyright terms    http://www.apnic.net/db/dbcopyright.html
+
+% Information related to '171.0.0.0 - 171.1.255.255'
+
+% Abuse contact for '171.0.0.0 - 171.1.255.255' is 'abuse@starhub.com'
+
+inetnum:        171.0.0.0 - 171.1.255.255
+netname:        STARHUBINTERNET-SG
+descr:          StarHub Internet Pte Ltd
+descr:          Singapore Broadband Access Provider
+country:        SG
+org:            ORG-SIPL5-AP
+admin-c:        SH1233-AP
+tech-c:         SH1233-AP
+abuse-c:        AS2611-AP
+status:         ALLOCATED PORTABLE
+remarks:        --------------------------------------------------------
+remarks:        To report network abuse, please contact mnt-irt
+remarks:        For troubleshooting, please contact tech-c and admin-c
+remarks:        Report invalid contact via www.apnic.net/invalidcontact
+remarks:        --------------------------------------------------------
+mnt-by:         APNIC-HM
+mnt-lower:      MAINT-AS4657-AP
+mnt-routes:     MAINT-AS4657-AP
+mnt-irt:        IRT-STARHUBINTERNET-SG
+last-modified:  2020-09-09T22:34:05Z
+source:         APNIC
+
+irt:            IRT-STARHUBINTERNET-SG
+address:        StarHub Ltd 67 Ubi Avenue 1 Singapore 408942 # 05-01 StarHub Green
+e-mail:         abuse@starhub.com
+abuse-mailbox:  abuse@starhub.com
+admin-c:        ACS7-AP
+tech-c:         ACS7-AP
+auth:           # Filtered
+remarks:        abuse@starhub.com was validated on 2024-08-19
+mnt-by:         MAINT-AS4657-AP
+last-modified:  2024-08-19T03:56:08Z
+source:         APNIC
+
+organisation:   ORG-SIPL5-AP
+org-name:       Starhub Ltd.
+org-type:       LIR
+country:        SG
+address:        67 Ubi Avenue 1
+address:        # 05-01
+address:        StarHub Green
+phone:          +65-68255000
+fax-no:         +65-68206008
+e-mail:         apnic-scv@starhub.com
+mnt-ref:        APNIC-HM
+mnt-by:         APNIC-HM
+last-modified:  2023-09-05T02:14:42Z
+source:         APNIC
+
+role:           ABUSE STARHUBINTERNETSG
+country:        ZZ
+address:        StarHub Ltd 67 Ubi Avenue 1 Singapore 408942 # 05-01 StarHub Green
+phone:          +000000000
+e-mail:         abuse@starhub.com
+admin-c:        ACS7-AP
+tech-c:         ACS7-AP
+nic-hdl:        AS2611-AP
+remarks:        Generated from irt object IRT-STARHUBINTERNET-SG
+remarks:        abuse@starhub.com was validated on 2024-08-19
+abuse-mailbox:  abuse@starhub.com
+mnt-by:         APNIC-ABUSE
+last-modified:  2024-08-19T03:56:57Z
+source:         APNIC
+
+role:           StarHub IP Administrator
+address:        c/o IP NOC
+                19 Tai Seng Drive
+                Singapore 535222
+country:        SG
+phone:          +65-6825-7878
+e-mail:         ipnoc@starhub.com
+admin-c:        SH1233-AP
+tech-c:         SH1233-AP
+nic-hdl:        SH1233-AP
+mnt-by:         MAINT-AS4657-AP
+last-modified:  2018-12-13T19:07:23Z
+abuse-mailbox:  abuse@starhub.com
+source:         APNIC
+
+% Information related to '171.0.0.0/24AS138345'
+
+route:          171.0.0.0/24
+origin:         AS138345
+descr:          Starhub Internet Pte Ltd
+                67 Ubi Avenue 1
+                # 05-01
+                StarHub Green
+mnt-by:         MAINT-AS4657-AP
+last-modified:  2021-06-03T08:19:25Z
+source:         APNIC
+
+% Information related to '171.0.0.0/24AS4657'
+
+route:          171.0.0.0/24
+origin:         AS4657
+descr:          Starhub Internet Pte Ltd
+                67 Ubi Avenue 1
+                # 05-01
+                StarHub Green
+mnt-by:         MAINT-AS4657-AP
+last-modified:  2021-06-03T08:18:51Z
+source:         APNIC
+
+% Information related to '171.0.0.0/24AS9874'
+
+route:          171.0.0.0/24
+origin:         AS9874
+descr:          Starhub Internet Pte Ltd
+                67 Ubi Avenue 1
+                # 05-01
+                StarHub Green
+mnt-by:         MAINT-AS4657-AP
+last-modified:  2021-06-03T08:19:48Z
+source:         APNIC
+
+% This query was served by the APNIC Whois Service version 1.88.25 (WHOIS-JP3)
+
+% Query time: 195 msec
+% WHEN: Tue Oct 08 17:59:27 AEDT 2024
+

--- a/testdata/whois_arin_net_170.txt
+++ b/testdata/whois_arin_net_170.txt
@@ -1,0 +1,72 @@
+
+#
+# ARIN WHOIS data and services are subject to the Terms of Use
+# available at: https://www.arin.net/resources/registry/whois/tou/
+#
+# If you see inaccuracies in the results, please report at
+# https://www.arin.net/resources/registry/whois/inaccuracy_reporting/
+#
+# Copyright 1997-2024, American Registry for Internet Numbers, Ltd.
+#
+
+
+NetRange:       170.0.0.0 - 170.0.3.255
+CIDR:           170.0.0.0/22
+NetName:        LACNIC-ERX-170-0-0-0
+NetHandle:      NET-170-0-0-0-1
+Parent:         NET170 (NET-170-0-0-0-0)
+NetType:        Transferred to LACNIC
+OriginAS:       
+Organization:   Latin American and Caribbean IP address Regional Registry (LACNIC)
+RegDate:        2010-11-03
+Updated:        2022-01-11
+Comment:        This IP address range is under LACNIC responsibility
+Comment:        for further allocations to users in LACNIC region.
+Comment:        Please see http://www.lacnic.net/ for further details,
+Comment:        or check the WHOIS server located at http://whois.lacnic.net
+Ref:            https://rdap.arin.net/registry/ip/170.0.0.0
+
+ResourceLink:  http://lacnic.net/cgi-bin/lacnic/whois
+ResourceLink:  whois.lacnic.net
+
+
+OrgName:        Latin American and Caribbean IP address Regional Registry
+OrgId:          LACNIC
+Address:        Rambla Republica de Mexico 6125
+City:           Montevideo
+StateProv:      
+PostalCode:     11400
+Country:        UY
+RegDate:        2002-07-27
+Updated:        2018-03-15
+Ref:            https://rdap.arin.net/registry/entity/LACNIC
+
+ReferralServer:  whois://whois.lacnic.net
+ResourceLink:  http://lacnic.net/cgi-bin/lacnic/whois
+
+OrgAbuseHandle: LWI100-ARIN
+OrgAbuseName:   LACNIC Whois Info
+OrgAbusePhone:  +598-2604-2222 
+OrgAbuseEmail:  abuse@lacnic.net
+OrgAbuseRef:    https://rdap.arin.net/registry/entity/LWI100-ARIN
+
+OrgTechHandle: LACNIC-ARIN
+OrgTechName:   LACNIC Whois Info
+OrgTechPhone:  +598-2604-2222 
+OrgTechEmail:  whois-contact@lacnic.net
+OrgTechRef:    https://rdap.arin.net/registry/entity/LACNIC-ARIN
+
+
+#
+# ARIN WHOIS data and services are subject to the Terms of Use
+# available at: https://www.arin.net/resources/registry/whois/tou/
+#
+# If you see inaccuracies in the results, please report at
+# https://www.arin.net/resources/registry/whois/inaccuracy_reporting/
+#
+# Copyright 1997-2024, American Registry for Internet Numbers, Ltd.
+#
+
+% Query time: 512 msec
+% WHEN: Tue Oct 08 18:06:40 AEDT 2024
+

--- a/testdata/whois_arin_net_174.txt
+++ b/testdata/whois_arin_net_174.txt
@@ -1,0 +1,79 @@
+
+
+#
+# ARIN WHOIS data and services are subject to the Terms of Use
+# available at: https://www.arin.net/resources/registry/whois/tou/
+#
+# If you see inaccuracies in the results, please report at
+# https://www.arin.net/resources/registry/whois/inaccuracy_reporting/
+#
+# Copyright 1997-2024, American Registry for Internet Numbers, Ltd.
+#
+
+
+NetRange:       174.0.0.0 - 174.7.255.255
+CIDR:           174.0.0.0/13
+NetName:        SHAW-COMM
+NetHandle:      NET-174-0-0-0-1
+Parent:         NET174 (NET-174-0-0-0-0)
+NetType:        Direct Allocation
+OriginAS:       AS6327
+Organization:   Shaw Communications Inc. (SHAWC)
+RegDate:        2008-11-19
+Updated:        2012-03-02
+Ref:            https://rdap.arin.net/registry/ip/174.0.0.0
+
+
+
+OrgName:        Shaw Communications Inc.
+OrgId:          SHAWC
+Address:        Suite 800
+Address:        630 - 3rd Ave. SW
+City:           Calgary
+StateProv:      AB
+PostalCode:     T2P-4L4
+Country:        CA
+RegDate:        2003-03-05
+Updated:        2024-03-28
+Ref:            https://rdap.arin.net/registry/entity/SHAWC
+
+ReferralServer:  rwhois://rwhois.shawcable.net:4321
+
+OrgAbuseHandle: SHAWA-ARIN
+OrgAbuseName:   SHAW ABUSE
+OrgAbusePhone:  +1-403-750-7420 
+OrgAbuseEmail:  internet.abuse@sjrb.ca
+OrgAbuseRef:    https://rdap.arin.net/registry/entity/SHAWA-ARIN
+
+OrgTechHandle: ZS178-ARIN
+OrgTechName:   IP Admin
+OrgTechPhone:  +1-416-786-1640 
+OrgTechEmail:  Adam.Pattenden@rci.rogers.com
+OrgTechRef:    https://rdap.arin.net/registry/entity/ZS178-ARIN
+
+OrgTechHandle: ZHUJI1-ARIN
+OrgTechName:   Zhu, Jing 
+OrgTechPhone:  +1-587-393-0668 
+OrgTechEmail:  jing.zhu@sjrb.ca
+OrgTechRef:    https://rdap.arin.net/registry/entity/ZHUJI1-ARIN
+
+RTechHandle: ZS178-ARIN
+RTechName:   IP Admin
+RTechPhone:  +1-416-786-1640 
+RTechEmail:  Adam.Pattenden@rci.rogers.com
+RTechRef:    https://rdap.arin.net/registry/entity/ZS178-ARIN
+
+
+#
+# ARIN WHOIS data and services are subject to the Terms of Use
+# available at: https://www.arin.net/resources/registry/whois/tou/
+#
+# If you see inaccuracies in the results, please report at
+# https://www.arin.net/resources/registry/whois/inaccuracy_reporting/
+#
+# Copyright 1997-2024, American Registry for Internet Numbers, Ltd.
+#
+
+% Query time: 622 msec
+% WHEN: Tue Oct 08 17:56:31 AEDT 2024
+

--- a/testdata/whois_iana_org_171.txt
+++ b/testdata/whois_iana_org_171.txt
@@ -1,0 +1,19 @@
+
+% IANA WHOIS server
+% for more information on IANA, visit http://www.iana.org
+% This query returned 1 object
+
+refer:        whois.apnic.net
+
+inetnum:      171.0.0.0 - 171.255.255.255
+organisation: Administered by APNIC
+status:       LEGACY
+
+whois:        whois.apnic.net
+
+changed:      1993-05
+source:       IANA
+
+% Query time: 872 msec
+% WHEN: Tue Oct 08 17:57:40 AEDT 2024
+

--- a/testdata/whois_iana_org_as264957.txt
+++ b/testdata/whois_iana_org_as264957.txt
@@ -1,0 +1,19 @@
+
+% IANA WHOIS server
+% for more information on IANA, visit http://www.iana.org
+% This query returned 1 object
+
+refer:        whois.lacnic.net
+
+as-block:     264605-265628
+organisation: Assigned by LACNIC
+
+whois:        whois.lacnic.net
+descr:        Assigned by LACNIC
+
+changed:      2014-09-05
+source:       IANA
+
+% Query time: 765 msec
+% WHEN: Tue Oct 08 18:09:52 AEDT 2024
+

--- a/testdata/whois_lacnic_net_170.txt
+++ b/testdata/whois_lacnic_net_170.txt
@@ -1,0 +1,48 @@
+
+% IP Client: 2001:f40:908:7e:b47d:e5a2:b31a:acbf
+ 
+% Copyright (c) Nic.br
+%  The use of the data below is only permitted as described in
+%  full by the Use and Privacy Policy at https://registro.br/upp ,
+%  being prohibited its distribution, commercialization or
+%  reproduction, in particular, to use it for advertising or
+%  any similar purpose.
+%  2024-10-08T04:08:21-03:00 - IP: 2001:f40:908:7e:b47d:e5a2:b31a:acbf
+
+inetnum:     170.0.0.0/22
+aut-num:     AS264957
+abuse-c:     CCPRU1
+owner:       Coopercitrus Cooperativa de Produtores Rurais
+ownerid:     45.236.791/0001-91
+responsible: Depto Redes Coopercitrus
+country:     BR
+owner-c:     CCPRU1
+tech-c:      CCPRU1
+inetrev:     170.0.0.0/22
+nserver:     srvdns01.coopercitrus.com.br
+nsstat:      20241004 AA
+nslastaa:    20241004
+nserver:     srvdns02.coopercitrus.com.br
+nsstat:      20241004 AA
+nslastaa:    20241004
+created:     20160509
+changed:     20180127
+
+nic-hdl-br:  CCPRU1
+person:      Coopercitrus Cooperativa de Prod Rurais
+e-mail:      noc@coopercitrus.com.br
+country:     BR
+created:     20180126
+changed:     20240220
+
+% Security and mail abuse issues should also be addressed to
+% cert.br, http://www.cert.br/ , respectivelly to cert@cert.br
+% and mail-abuse@cert.br
+%
+% whois.registro.br accepts only direct match queries. Types
+% of queries are: domain (.br), registrant (tax ID), ticket,
+% provider, CIDR block, IP and ASN.
+
+% Query time: 737 msec
+% WHEN: Tue Oct 08 18:08:21 AEDT 2024
+

--- a/testdata/whois_lacnic_net_as264957.txt
+++ b/testdata/whois_lacnic_net_as264957.txt
@@ -1,0 +1,42 @@
+
+% IP Client: 2001:f40:908:7e:b47d:e5a2:b31a:acbf
+ 
+% Copyright (c) Nic.br
+%  The use of the data below is only permitted as described in
+%  full by the Use and Privacy Policy at https://registro.br/upp ,
+%  being prohibited its distribution, commercialization or
+%  reproduction, in particular, to use it for advertising or
+%  any similar purpose.
+%  2024-10-08T04:11:37-03:00 - IP: 2001:f40:908:7e:b47d:e5a2:b31a:acbf
+
+aut-num:     AS264957
+owner:       Coopercitrus Cooperativa de Produtores Rurais
+ownerid:     45.236.791/0001-91
+responsible: Depto Redes Coopercitrus
+country:     BR
+owner-c:     CCPRU1
+routing-c:   CCPRU1
+abuse-c:     CCPRU1
+created:     20160509
+changed:     20180127
+inetnum:     170.0.0.0/22
+inetnum:     2804:1f22::/32
+
+nic-hdl-br:  CCPRU1
+person:      Coopercitrus Cooperativa de Prod Rurais
+e-mail:      noc@coopercitrus.com.br
+country:     BR
+created:     20180126
+changed:     20240220
+
+% Security and mail abuse issues should also be addressed to
+% cert.br, http://www.cert.br/ , respectivelly to cert@cert.br
+% and mail-abuse@cert.br
+%
+% whois.registro.br accepts only direct match queries. Types
+% of queries are: domain (.br), registrant (tax ID), ticket,
+% provider, CIDR block, IP and ASN.
+
+% Query time: 695 msec
+% WHEN: Tue Oct 08 18:11:37 AEDT 2024
+

--- a/whois.go
+++ b/whois.go
@@ -249,13 +249,14 @@ func getExtension(domain string) string {
 	return ext
 }
 
-// getServer returns server from whois data
+// getServer returns the first referral server from whois data (if any)
 func getServer(data string) (string, string) {
 	tokens := []string{
 		"Registrar WHOIS Server: ",
 		"whois: ",
 		"ReferralServer: ",
 		"refer: ",
+		"%referral ", // e.g. %referral rwhois://root.rwhois.net:4321/auth-area=.
 	}
 
 	for _, token := range tokens {
@@ -273,6 +274,12 @@ func getServer(data string) (string, string) {
 			if strings.Contains(server, ":") {
 				v := strings.Split(server, ":")
 				server, port = v[0], v[1]
+				// Strip trailing non-numeric characters from port
+				reNumericTrailing := regexp.MustCompile(`^(\d+)\D.*$`)
+				matches := reNumericTrailing.FindStringSubmatch(port)
+				if matches != nil {
+					port = matches[1]
+				}
 			}
 			return server, port
 		}

--- a/whois_test.go
+++ b/whois_test.go
@@ -21,6 +21,7 @@ package whois
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -164,5 +165,32 @@ func TestIsASN(t *testing.T) {
 
 	for _, v := range tests {
 		assert.Equal(t, IsASN(v.in), v.out)
+	}
+}
+
+func TestGetServer(t *testing.T) {
+	tests := []struct {
+		filename string
+		server   string
+		port     string
+	}{
+		{"whois_arin_net_170.txt", "whois.lacnic.net", "43"},
+		{"whois_iana_org_171.txt", "whois.apnic.net", "43"},
+		{"whois_arin_net_174.txt", "rwhois.shawcable.net", "4321"},
+		{"rwhois_shawcable_net_4321_174.txt", "root.rwhois.net", "4321"},
+		{"whois_iana_org_as264957.txt", "whois.lacnic.net", "43"},
+		// Non-referral responses
+		{"whois_lacnic_net_170.txt", "", ""},
+		{"whois_apnic_net_171.txt", "", ""},
+		{"whois_lacnic_net_as264957.txt", "", ""},
+	}
+
+	for _, tc := range tests {
+		data, err := os.ReadFile("testdata/" + tc.filename)
+		assert.Nil(t, err)
+
+		server, port := getServer(string(data))
+		assert.Equal(t, server, tc.server)
+		assert.Equal(t, port, tc.port)
 	}
 }


### PR DESCRIPTION
This PR addresses the issue raised in [Issue 49](https://github.com/likexian/whois/issues/49)

It also includes a `getServer` unit test to check that I didn't break the existing behaviour, with whois responses in `testdata` files, as that seemed cleaner than including the text inline in `whois_test.go`?
