### PR TITLE
feat: Add Option to Control Referral Chain Concatenation in WHOIS Responses

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -187,7 +187,7 @@ func (c *Client) Whois(domain string, servers ...string) (result string, err err
 
 	data, err := c.rawQuery(domain, refServer, refPort)
 	if err == nil {
-		if !c.disableReferralChain {
+		if c.disableReferralChain {
 			result = data
 		} else {
 			result += data
@@ -230,6 +230,15 @@ func (c *Client) rawQuery(domain, server, port string) (string, error) {
 	_ = conn.SetWriteDeadline(time.Now().Add(c.timeout - elapsed))
 	_, err = conn.Write([]byte(domain + "\r\n"))
 	if err != nil {
+		// Some servers may refuse a request with a reason, immediately closing the connection after sending.
+		// For example, GoDaddy returns "Number of allowed queries exceeded.\r\n", and immediately closes the connection.
+		//
+		// We return both the response _and_ the error, to allow callers to try to parse the response, while
+		// still letting them know an error occurred. In particular, this helps catch rate limit errors.
+		buffer, _ := io.ReadAll(conn)
+		if len(buffer) > 0 {
+			return string(buffer), err
+		}
 		return "", fmt.Errorf("whois: send to whois server failed: %w", err)
 	}
 
@@ -238,6 +247,15 @@ func (c *Client) rawQuery(domain, server, port string) (string, error) {
 	_ = conn.SetReadDeadline(time.Now().Add(c.timeout - elapsed))
 	buffer, err := io.ReadAll(conn)
 	if err != nil {
+		if len(buffer) > 0 {
+			// Some servers may refuse a request with a reason, immediately closing the connection after sending.
+			// For example, GoDaddy returns "Number of allowed queries exceeded.\r\n", and immediately closes the connection.
+			//
+			// We return both the response _and_ the error, to allow callers to try to parse the response, while
+			// still letting them know an error occurred (potentially short reads). In particular, this helps
+			// catch rate limit errors.
+			return string(buffer), err
+		}
 		return "", fmt.Errorf("whois: read from whois server failed: %w", err)
 	}
 

--- a/whois.go
+++ b/whois.go
@@ -239,6 +239,7 @@ func (c *Client) rawQuery(domain, server, port string) (string, error) {
 		if len(buffer) > 0 {
 			return string(buffer), err
 		}
+
 		return "", fmt.Errorf("whois: send to whois server failed: %w", err)
 	}
 
@@ -256,6 +257,7 @@ func (c *Client) rawQuery(domain, server, port string) (string, error) {
 			// catch rate limit errors.
 			return string(buffer), err
 		}
+
 		return "", fmt.Errorf("whois: read from whois server failed: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Currently, when a WHOIS server is explicitly provided, the library concatenates all responses from the referral chain before returning the final result. However, when no server is provided, the library automatically discovers the WHOIS server, follows referrals, and only returns the final response from the last queried server.

This behavior leads to inconsistent outputs depending on whether a WHOIS server is explicitly set. To address this, this PR introduces a new option (SetDisableReferralChain) that allows users to control whether all responses should be concatenated or only the final response should be returned.

## Changes

* Add a `disableReferralChain` flag to the Client struct (default: false to maintain backward compatibility).
* Modify the referral-handling logic to respect this flag when a server is explicitly set.
* Ensure the library’s behavior remains consistent whether a WHOIS server is manually specified or auto-discovered.

## Why this change?

This provides more flexibility for users who expect consistent behavior regardless of how the WHOIS query is initiated. Some use cases (e.g., automated WHOIS parsing) may require only the final response, avoiding redundant or misleading intermediary outputs.

## Output Example

Below you have an example output from multiple examples of setting the `server` or not, and different behaviors of `disableReferralChain`.

<details>

```

🔍 Querying WHOIS for: influxdata-test.com (Server: , disableReferralChain: false)

✅ WHOIS Response:
No match for "INFLUXDATA-TEST.COM".
>>> Last update of whois database: 2025-02-20T23:46:26Z <<<

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability.  VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.

% Query time: 733 msec
% WHEN: Thu Feb 20 23:46:37 WET 2025

2025/02/20 23:46:38 ⚠️  Error parsing WHOIS response: whoisparser: domain is not found

🔍 Querying WHOIS for: influxdata-test.com (Server: whois.iana.org, disableReferralChain: false)

✅ WHOIS Response:
% IANA WHOIS server
% for more information on IANA, visit http://www.iana.org
% This query returned 1 object

refer:        whois.verisign-grs.com

domain:       COM

organisation: VeriSign Global Registry Services
address:      12061 Bluemont Way
address:      Reston VA 20190
address:      United States of America (the)

contact:      administrative
name:         Registry Customer Service
organisation: VeriSign Global Registry Services
address:      12061 Bluemont Way
address:      Reston VA 20190
address:      United States of America (the)
phone:        +1 703 925-6999
fax-no:       +1 703 948 3978
e-mail:       info@verisign-grs.com

contact:      technical
name:         Registry Customer Service
organisation: VeriSign Global Registry Services
address:      12061 Bluemont Way
address:      Reston VA 20190
address:      United States of America (the)
phone:        +1 703 925-6999
fax-no:       +1 703 948 3978
e-mail:       info@verisign-grs.com

nserver:      A.GTLD-SERVERS.NET 192.5.6.30 2001:503:a83e:0:0:0:2:30
nserver:      B.GTLD-SERVERS.NET 192.33.14.30 2001:503:231d:0:0:0:2:30
nserver:      C.GTLD-SERVERS.NET 192.26.92.30 2001:503:83eb:0:0:0:0:30
nserver:      D.GTLD-SERVERS.NET 192.31.80.30 2001:500:856e:0:0:0:0:30
nserver:      E.GTLD-SERVERS.NET 192.12.94.30 2001:502:1ca1:0:0:0:0:30
nserver:      F.GTLD-SERVERS.NET 192.35.51.30 2001:503:d414:0:0:0:0:30
nserver:      G.GTLD-SERVERS.NET 192.42.93.30 2001:503:eea3:0:0:0:0:30
nserver:      H.GTLD-SERVERS.NET 192.54.112.30 2001:502:8cc:0:0:0:0:30
nserver:      I.GTLD-SERVERS.NET 192.43.172.30 2001:503:39c1:0:0:0:0:30
nserver:      J.GTLD-SERVERS.NET 192.48.79.30 2001:502:7094:0:0:0:0:30
nserver:      K.GTLD-SERVERS.NET 192.52.178.30 2001:503:d2d:0:0:0:0:30
nserver:      L.GTLD-SERVERS.NET 192.41.162.30 2001:500:d937:0:0:0:0:30
nserver:      M.GTLD-SERVERS.NET 192.55.83.30 2001:501:b1f9:0:0:0:0:30
ds-rdata:     19718 13 2 8acbb0cd28f41250a80a491389424d341522d946b0da0c0291f2d3d771d7805a

whois:        whois.verisign-grs.com

status:       ACTIVE
remarks:      Registration information: http://www.verisigninc.com

created:      1985-01-01
changed:      2023-12-07
source:       IANA

No match for "INFLUXDATA-TEST.COM".
>>> Last update of whois database: 2025-02-20T23:46:26Z <<<

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability.  VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.

% Query time: 409 msec
% WHEN: Thu Feb 20 23:46:38 WET 2025


📌 Parsed WHOIS Info:
{Domain:0x140001a0000 Registrar:<nil> Registrant:0x140001a01c0 Administrative:0x140001a02a0 Technical:0x140001a0380 Billing:<nil>}

🔍 Querying WHOIS for: influxdata-test.com (Server: whois.verisign-grs.com, disableReferralChain: false)

✅ WHOIS Response:
No match for "INFLUXDATA-TEST.COM".
>>> Last update of whois database: 2025-02-20T23:46:26Z <<<

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability.  VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.

% Query time: 80 msec
% WHEN: Thu Feb 20 23:46:39 WET 2025

2025/02/20 23:46:39 ⚠️  Error parsing WHOIS response: whoisparser: domain is not found

🔍 Querying WHOIS for: influxdata-test.com (Server: , disableReferralChain: true)

✅ WHOIS Response:
No match for "INFLUXDATA-TEST.COM".
>>> Last update of whois database: 2025-02-20T23:46:26Z <<<

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability.  VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.

% Query time: 302 msec
% WHEN: Thu Feb 20 23:46:39 WET 2025

2025/02/20 23:46:39 ⚠️  Error parsing WHOIS response: whoisparser: domain is not found

🔍 Querying WHOIS for: influxdata-test.com (Server: whois.iana.org, disableReferralChain: true)

✅ WHOIS Response:
No match for "INFLUXDATA-TEST.COM".
>>> Last update of whois database: 2025-02-20T23:46:26Z <<<

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability.  VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.

% Query time: 424 msec
% WHEN: Thu Feb 20 23:46:39 WET 2025

2025/02/20 23:46:39 ⚠️  Error parsing WHOIS response: whoisparser: domain is not found

🔍 Querying WHOIS for: influxdata-test.com (Server: whois.verisign-grs.com, disableReferralChain: true)

✅ WHOIS Response:
No match for "INFLUXDATA-TEST.COM".
>>> Last update of whois database: 2025-02-20T23:46:26Z <<<

NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.

TERMS OF USE: You are not authorized to access or query our Whois
database through the use of electronic processes that are high-volume and
automated except as reasonably necessary to register domain names or
modify existing registrations; the Data in VeriSign Global Registry
Services' ("VeriSign") Whois database is provided by VeriSign for
information purposes only, and to assist persons in obtaining information
about or related to a domain name registration record. VeriSign does not
guarantee its accuracy. By submitting a Whois query, you agree to abide
by the following terms of use: You agree that you may use this Data only
for lawful purposes and that under no circumstances will you use this Data
to: (1) allow, enable, or otherwise support the transmission of mass
unsolicited, commercial advertising or solicitations via e-mail, telephone,
or facsimile; or (2) enable high volume, automated, electronic processes
that apply to VeriSign (or its computer systems). The compilation,
repackaging, dissemination or other use of this Data is expressly
prohibited without the prior written consent of VeriSign. You agree not to
use electronic processes that are automated and high-volume to access or
query the Whois database except as reasonably necessary to register
domain names or modify existing registrations. VeriSign reserves the right
to restrict your access to the Whois database in its sole discretion to ensure
operational stability.  VeriSign may restrict or terminate your access to the
Whois database for failure to abide by these terms of use. VeriSign
reserves the right to modify these terms at any time.

The Registry database contains ONLY .COM, .NET, .EDU domains and
Registrars.

% Query time: 201 msec
% WHEN: Thu Feb 20 23:46:39 WET 2025

2025/02/20 23:46:40 ⚠️  Error parsing WHOIS response: whoisparser: domain is not found

```
</details>