### PR TITLE
fix using unreachable referral server

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -312,7 +312,12 @@ func getServer(data string) (string, string) {
 					port = matches[1]
 				}
 			}
-			return server, port
+			// basic connection test
+			conn, err := net.Dial("tcp", net.JoinHostPort(server, port))
+			if err == nil {
+				defer conn.Close()
+				return server, port
+			}
 		}
 	}
 


### PR DESCRIPTION
This blocks some specific domains from being checked, for example domains registered via scaleway, which use bookmyname.
The whois client find the referrer server and tries to use that, without first checking if the server is reachable.